### PR TITLE
Make explicit that image must be available on the host

### DIFF
--- a/02-containerized-docker-engine/README.md
+++ b/02-containerized-docker-engine/README.md
@@ -27,3 +27,7 @@ the containers for the users' Shiny apps.
 
 * The custom bridge network `sp-example-net` is needed to allow the containers to access each other using
 the container ID as hostname.
+
+* ShinyProxy expects relevant Docker images to be already available on the host. Before running this example, pull the Docker image used in this example with:
+
+`sudo docker pull openanalytics/shinyproxy-demo`


### PR DESCRIPTION
To users trying out the example files it may not be immediately obvious that the Docker image must be available on the host, and the error message is very generic. This seems to be an issue with other users that test ShinyProxy, see also: https://github.com/openanalytics/shinyproxy/issues/82