### PR TITLE
Allow graceful shutdown in Kubernetes config

### DIFF
--- a/03-containerized-kubernetes/sp-deployment.yaml
+++ b/03-containerized-kubernetes/sp-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     matchLabels:
       run: shinyproxy
   replicas: 1
-  template:
+  template:  
     metadata:
       labels:
         run: shinyproxy
@@ -23,3 +23,7 @@ spec:
         imagePullPolicy: Never
         ports:
         - containerPort: 8001
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sh", "-c", "sleep 5"] # wait 5 seconds to let shinyproxy remove the pods on graceful shutdown        


### PR DESCRIPTION
Allow graceful shutdown by delaying the SIGTERM to the sidecar container by some time, for example, 5s. This solves the issue here:
https://github.com/openanalytics/shinyproxy/issues/169